### PR TITLE
send emails as htmls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ wheels/
 *.egg
 MANIFEST
 .py3
+Pipfile
+Pipfile.lock
 requirements.txt
 app.py
 tests

--- a/README.md
+++ b/README.md
@@ -131,6 +131,52 @@ async def send_file(background_tasks: BackgroundTasks,file: UploadFile = File(..
 
 ```
 
+###  Using Jinja2 HTML Templates
+
+The email folder must be present within your applications working directory.
+
+In sending HTML emails, the CSS expected by mail servers -outlook, google, etc- must be inline CSS. Fastapi mail passes _"body"_ to the rendered template. In creating the template for emails the dynamic objects should be used with the assumption that the variable is named "_body_" and that it is a python dict.
+
+check out jinja2 for more details 
+https://jinja.palletsprojects.com/en/2.11.x/
+
+
+```python
+
+
+class EmailSchema(BaseModel):
+    email: List[EmailStr]
+    body: Dict[str, Any]
+
+conf = ConnectionConfig(
+    MAIL_USERNAME = "YourUsername",
+    MAIL_PASSWORD = "strong_password",
+    MAIL_FROM = "your@email.com",
+    MAIL_PORT = 587,
+    MAIL_SERVER = "your mail server",
+    MAIL_TLS = True,
+    MAIL_SSL = False,
+    TEMPLATE_FOLDER='./email templates folder'
+)
+
+
+@app.post("/email")
+async def send_with_template(email: EmailSchema) -> JSONResponse:
+
+    message = MessageSchema(
+        subject="Fastapi-Mail module",
+        recipients=email.dict().get("email"),  # List of recipients, as many as you can pass 
+        body=email.dict().get("body"),
+        subtype="html"
+        )
+
+    fm = FastMail(conf)
+    await fm.send_message(message, template_name="email_template.html") ##optional field template_name is the name of the html file(jinja template) to use from the email template folder
+    return JSONResponse(status_code=200, content={"message": "email has been sent"})
+
+
+```
+
 
 # Contributing
 Fell free to open issue and send pull request.

--- a/fastapi_mail/config.py
+++ b/fastapi_mail/config.py
@@ -1,16 +1,29 @@
+import os
+from typing import Any
 from pydantic import BaseSettings as Settings
-from pydantic import EmailStr
+from pydantic import EmailStr, validator
+from fastapi_mail.schemas import validate_path
+from jinja2 import Environment, FileSystemLoader
 
 
 class ConnectionConfig(Settings):
 
-    MAIL_USERNAME:  str
-    MAIL_PASSWORD: str 
-    MAIL_PORT: int  = 465
-    MAIL_SERVER: str 
+    MAIL_USERNAME: str
+    MAIL_PASSWORD: str
+    MAIL_PORT: int = 465
+    MAIL_SERVER: str
     MAIL_TLS: bool = False
     MAIL_SSL: bool = True
     MAIL_DEBUG: int = 1
     MAIL_FROM: EmailStr
+    TEMPLATE_FOLDER: Any = None
 
+    @validator("TEMPLATE_FOLDER", pre=True)
+    def create_template_engine(cls, v):
+        template_env = None
+        if isinstance(v, str):
 
+            if os.path.isdir(v) and os.access(v, os.R_OK) and validate_path(v):
+                template_env = Environment(
+                    loader=FileSystemLoader(v))
+        return template_env

--- a/fastapi_mail/schemas.py
+++ b/fastapi_mail/schemas.py
@@ -11,7 +11,7 @@ class MessageSchema(BaseModel):
     recipients: List[EmailStr]
     attachments: List[Any] = []
     subject: str = ""
-    body: str = None
+    body: Union[str, dict] = None
     cc: List[EmailStr] = []
     bcc: List[EmailStr] = []
     charset: str = "utf-8"


### PR DESCRIPTION
A new feature to allow users to send emails which are actually html documents with inline CSS fro styling. The templates can have dynamic values within them since by default jinja2 is being used under the hood. 
**TEMPLATE_FOLDER** is the path to the template directory, if the path doesn't exist it will return None.
```
    TEMPLATE_FOLDER: Any = None
```
With this setup, fastapi mail setups a jinja2 environment which points to the given folder which has various html documents present within it. 

```python
    async def get_mail_template(self, env_path, template_name):
        template = env_path.get_template(template_name)
        return template

    async def __preape_message(self, message, template=None):
        if hasattr(message, "body") and template is not None:
            message.body = template.render(body=message.body)
            if hasattr(message, "subtype") and getattr(message, "subtype") != "html":
                message.subtype = "html"
     
        ......
```
The __preape_message function is extended so that jinja2 templating can be used, it also goes ahead to set up subtype in the event that the user forgets to include it. The template passed into **__preape_message** is comes from the **get_mail_template** function as is a jinja2 variable.

to address #21 