### PR TITLE
intuitive email mocking with fastapi-mail

### DIFF
--- a/fastapi_mail/config.py
+++ b/fastapi_mail/config.py
@@ -2,8 +2,9 @@ import os
 from typing import Any
 from pydantic import BaseSettings as Settings
 from pydantic import EmailStr, validator
-from fastapi_mail.schemas import validate_path
 from jinja2 import Environment, FileSystemLoader
+from fastapi_mail.schemas import validate_path
+from fastapi_mail.errors import TemplateFolderDoesNotExist
 
 
 class ConnectionConfig(Settings):
@@ -14,15 +15,32 @@ class ConnectionConfig(Settings):
     MAIL_SERVER: str
     MAIL_TLS: bool = False
     MAIL_SSL: bool = True
-    MAIL_DEBUG: int = 1
+    MAIL_DEBUG: int = 0
     MAIL_FROM: EmailStr
     MAIL_FROM_NAME: str = None
     TEMPLATE_FOLDER: Any = None
+    SUPPRESS_SEND: int = 0
+
+    @validator("SUPPRESS_SEND")
+    def validate_email_suppression(cls, v):
+        if v < 0:
+            raise ValueError(f"Expected either 0 or 1, got {v}")
+        if v > 1:
+            raise ValueError(f"Expected either 0 or 1, got {v}")
+
+    @validator("MAIL_DEBUG")
+    def validate_email_debug(cls, v):
+        if v < 0:
+            raise ValueError(f"Expected either 0 or 1, got {v}")
+        if v > 1:
+            raise ValueError(f"Expected either 0 or 1, got {v}")
 
     @validator("TEMPLATE_FOLDER", pre=True)
     def create_template_engine(cls, v):
         template_env = None
         if isinstance(v, str):
+            if not os.path.exists(v):
+                raise TemplateFolderDoesNotExist(f"{v} is not a valid path to an email template folder")
 
             if os.path.isdir(v) and os.access(v, os.R_OK) and validate_path(v):
                 template_env = Environment(

--- a/fastapi_mail/errors.py
+++ b/fastapi_mail/errors.py
@@ -14,3 +14,8 @@ class PydanticClassRequired(Exception):
 
     def __init__(self, expression):
         self.expression = expression
+
+class TemplateFolderDoesNotExist(Exception):
+
+    def __init__(self, expression):
+        self.expression = expression

--- a/fastapi_mail/msg.py
+++ b/fastapi_mail/msg.py
@@ -16,7 +16,7 @@ from email.encoders import encode_base64
 class MailMsg:
     """
     Preaparation of class for email text
-    
+
     :param subject: email subject header
     :param recipients: list of email addresses
     :param body: plain text message
@@ -31,22 +31,19 @@ class MailMsg:
         self.__dict__.update(entries)
         self.msgId = make_msgid()
 
-
     def _mimetext(self, text, subtype="plain"):
         """Creates a MIMEText object"""
 
         return MIMEText(text, _subtype=self.subtype, _charset=self.charset)
 
-
     async def attach_file(self, message, attachment):
 
         print(attachment)
-        
+
         for file in attachment:
-        
+
             part = MIMEBase(_maintype="application", _subtype="octet-stream")
 
-            
             part.set_payload(await file.read())
             encode_base64(part)
 
@@ -59,35 +56,30 @@ class MailMsg:
                     filename = filename.encode('utf8')
 
             filename = ('UTF8', '', filename)
-            
 
             part.add_header(
                 'Content-Disposition',
                 "attachment",
                 filename=filename)
-            
 
             self.message.attach(part)
 
-
-    
-    async def _message(self,sender):
+    async def _message(self, sender):
         """Creates the email message"""
-            
+
         self.message = MIMEMultipart()
         self.message.set_charset(self.charset)
         self.message['Date'] = formatdate(time.time(), localtime=True)
         self.message['Message-ID'] = self.msgId
-        self.message["To"] =  ', '.join(self.recipients)
+        self.message["To"] = ', '.join(self.recipients)
         self.message["From"] = sender
-
 
         if self.subject:
             self.message["Subject"] = (self.subject)
-           
+
         if self.cc:
             self.message["Cc"] = ', '.join(self.cc)
-        
+
         if self.bcc:
             self.message["Bcc"] = ', '.join(self.bcc)
 
@@ -97,13 +89,11 @@ class MailMsg:
         if self.attachments:
             await self.attach_file(self.message, self.attachments)
 
-
         return self.message
 
-    
     async def as_string(self):
         return await self._message().as_string()
-        
+
     def as_bytes(self):
         return self._message().as_bytes()
 
@@ -112,4 +102,3 @@ class MailMsg:
 
     def __bytes__(self):
         return self.as_bytes()
-


### PR DESCRIPTION
A way to allow unit testing of application's email routes with[ pytest ](https://docs.pytest.org/en/latest/)or [unittest](https://docs.python.org/3/library/unittest.html) via mocking by fastapi_mail without actually sending out any emails. 


application.py
```python
conf = ConnectionConfig(
    MAIL_USERNAME = "YourUsername",
    MAIL_PASSWORD = "strong_password",
    MAIL_FROM = "your@email.com",
    MAIL_PORT = 587,
    MAIL_SERVER = "your mail server",
    MAIL_TLS = True,
    MAIL_SSL = False,
    TEMPLATE_FOLDER='./email templates folder',
    # if no indicated SUPPRESS_SEND defaults to 0 (false) as below
    SUPPRESS_SEND=0
)

fm = FastMail(conf)

@app.post("/email")
async def simple_send(email: EmailSchema) -> JSONResponse:
    message = MessageSchema(
        subject="Testing",
        recipients=email.dict().get("email"),  # List of recipients, as many as you can pass 
        body=html,
        subtype="html"
        )
    await fm.send_message(message)
    return JSONResponse(status_code=200, content={"message": "email has been sent"})
```

test.py
```python
from application.py import fm

# make this setting available as a fixture through conftest.py if you plan on using pytest
fm.config.SUPPRESS_SEND = 1

with fm.record_messages() as outbox:
    response = app.test_client.get("/email")
    assert len(outbox) == 1
    assert outbox[0].subject == "Testing"
```


This will allow for more intuitive application mail testing via mocking and avoids bugging out email servers with dummy emails resulting in a potential block from that server, and this also eliminates the complexity of having to create a personal server to test sending outgoing mails.

This PR was heavily influenced by the Flask-Mail testing function