### PR TITLE
:pencil2: Fix wrong parameter in example.md

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -33,7 +33,7 @@ conf = ConnectionConfig(
     MAIL_FROM_NAME="Desired Name"
     MAIL_TLS = True,
     MAIL_SSL = False,
-    USER_CREDENTIALS = True
+    USE_CREDENTIALS = True
 )
 
 app = FastAPI()


### PR DESCRIPTION
This commit fixes a typo/bug in docs/examples.md.
The parameter is called USE_CREDENTIALS, and not
USER_CREDENTIALS as mentioned.