### PR TITLE
fix jinja2 templates

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -130,7 +130,7 @@ conf = ConnectionConfig(
     MAIL_SERVER = "your mail server",
     MAIL_TLS = True,
     MAIL_SSL = False,
-    TEMPLATE_FOLDER='./email '
+    TEMPLATE_FOLDER = Path(__file__).parent / 'templates',
 )
 
 
@@ -140,8 +140,7 @@ async def send_with_template(email: EmailSchema) -> JSONResponse:
     message = MessageSchema(
         subject="Fastapi-Mail module",
         recipients=email.dict().get("email"),  # List of recipients, as many as you can pass 
-        body=email.dict().get("body"),
-        subtype="html"
+        template_body=email.dict().get("body"),
         )
 
     fm = FastMail(conf)
@@ -349,7 +348,7 @@ conf = ConnectionConfig(
     MAIL_SERVER = "your mail server",
     MAIL_TLS = True,
     MAIL_SSL = False,
-    TEMPLATE_FOLDER='./email templates folder',
+    TEMPLATE_FOLDER = Path(__file__).parent / 'templates',
 
     # if no indicated SUPPRESS_SEND defaults to 0 (false) as below
     # SUPPRESS_SEND=1

--- a/fastapi_mail/config.py
+++ b/fastapi_mail/config.py
@@ -25,6 +25,8 @@ class ConnectionConfig(Settings):
     @validator("TEMPLATE_FOLDER")
     def template_folder_validator(cls, v):
         """Validate the template folder directory."""
+        if not v:
+            return
         # need to convert ``PathLike`` object
         fp = str(v)
         if not os.path.exists(fp) or not os.path.isdir(fp) or not os.access(fp, os.R_OK):
@@ -37,5 +39,5 @@ class ConnectionConfig(Settings):
         folder = self.TEMPLATE_FOLDER
         if not folder:
             raise ValueError("Class initialization did not include a ``TEMPLATE_FOLDER`` ``PathLike`` object.")
-        template_env = Environment(loader=FileSystemLoader(self.TEMPLATE_FOLDER))
+        template_env = Environment(loader=FileSystemLoader(folder))
         return template_env

--- a/fastapi_mail/config.py
+++ b/fastapi_mail/config.py
@@ -1,12 +1,10 @@
 import os
-import functools as fn
 from typing import Optional
 
 from pydantic import BaseSettings as Settings, conint
 from pydantic import EmailStr, validator, DirectoryPath
 from jinja2 import Environment, FileSystemLoader
 
-from fastapi_mail.schemas import validate_path
 from fastapi_mail.errors import TemplateFolderDoesNotExist
 
 
@@ -29,12 +27,11 @@ class ConnectionConfig(Settings):
         """Validate the template folder directory."""
         # need to convert ``PathLike`` object
         fp = str(v)
-        if not os.path.exists(fp) or not os.path.isdir(fp) or not os.access(fp, os.R_OK) or not validate_path(fp):
+        if not os.path.exists(fp) or not os.path.isdir(fp) or not os.access(fp, os.R_OK):
             raise TemplateFolderDoesNotExist(
                 f"{v!r} is not a valid path to an email template folder")
         return v
 
-    @fn.cache
     def template_engine(self) -> Environment:
         """Return template environment."""
         folder = self.TEMPLATE_FOLDER

--- a/fastapi_mail/config.py
+++ b/fastapi_mail/config.py
@@ -1,8 +1,11 @@
 import os
-from typing import Any
+import functools as fn
+from typing import Optional
+
 from pydantic import BaseSettings as Settings, conint
-from pydantic import EmailStr, validator
+from pydantic import EmailStr, validator, DirectoryPath
 from jinja2 import Environment, FileSystemLoader
+
 from fastapi_mail.schemas import validate_path
 from fastapi_mail.errors import TemplateFolderDoesNotExist
 
@@ -16,20 +19,26 @@ class ConnectionConfig(Settings):
     MAIL_SSL: bool = True
     MAIL_DEBUG: conint(gt=-1, lt=2) = 0
     MAIL_FROM: EmailStr
-    MAIL_FROM_NAME: str = None
-    TEMPLATE_FOLDER: Any = None
+    MAIL_FROM_NAME: Optional[str] = None
+    TEMPLATE_FOLDER: Optional[DirectoryPath] = None
     SUPPRESS_SEND: conint(gt=-1, lt=2) = 0
     USE_CREDENTIALS: bool = True
 
-    @validator("TEMPLATE_FOLDER", pre=True)
-    def create_template_engine(cls, v):
-        template_env = None
-        if isinstance(v, str):
-            if not os.path.exists(v):
-                raise TemplateFolderDoesNotExist(
-                    f"{v} is not a valid path to an email template folder")
+    @validator("TEMPLATE_FOLDER")
+    def template_folder_validator(cls, v):
+        """Validate the template folder directory."""
+        # need to convert ``PathLike`` object
+        fp = str(v)
+        if not os.path.exists(fp) or not os.path.isdir(fp) or not os.access(fp, os.R_OK) or not validate_path(fp):
+            raise TemplateFolderDoesNotExist(
+                f"{v!r} is not a valid path to an email template folder")
+        return v
 
-            if os.path.isdir(v) and os.access(v, os.R_OK) and validate_path(v):
-                template_env = Environment(
-                    loader=FileSystemLoader(v))
+    @fn.cache
+    def template_engine(self) -> Environment:
+        """Return template environment."""
+        folder = self.TEMPLATE_FOLDER
+        if not folder:
+            raise ValueError("Class initialization did not include a ``TEMPLATE_FOLDER`` ``PathLike`` object.")
+        template_env = Environment(loader=FileSystemLoader(self.TEMPLATE_FOLDER))
         return template_env

--- a/fastapi_mail/fastmail.py
+++ b/fastapi_mail/fastmail.py
@@ -57,8 +57,9 @@ class FastMail(_MailMixin):
 
     async def __prepare_message(self, message: MessageSchema, template=None):
         if template is not None:
-            if message.body and not message.html:
-                message.body = template.render(body=message.body)
+            template_body = message.template_body
+            if template_body and not message.html:
+                message.template_body = template.render(body=template_body)
                 message.subtype = "html"
             elif message.html:
                 message.html = template.render(body=message.html)
@@ -78,7 +79,7 @@ class FastMail(_MailMixin):
          ''')
 
         if self.config.TEMPLATE_FOLDER and template_name:
-            template = await self.get_mail_template(self.config.TEMPLATE_FOLDER, template_name)
+            template = await self.get_mail_template(self.config.template_engine(), template_name)
             msg = await self.__prepare_message(message, template)
         else:
             msg = await self.__prepare_message(message)

--- a/fastapi_mail/msg.py
+++ b/fastapi_mail/msg.py
@@ -90,10 +90,13 @@ class MailMsg:
             self.message["Reply-To"] = ', '.join(self.reply_to)
 
         if self.body:
+            self.message.attach(self._mimetext(self.body))
+
+        if self.template_body:
             if not self.html and self.subtype:
                 self.message.attach(self._mimetext(self.body, self.subtype))
             else:
-                self.message.attach(self._mimetext(self.body))
+                raise ValueError("tried to send jinja2 template and html")
 
         if self.html:
             self.message.attach(self._mimetext(self.html, "html"))

--- a/fastapi_mail/msg.py
+++ b/fastapi_mail/msg.py
@@ -1,5 +1,6 @@
 import time
 import sys
+import warnings
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
@@ -16,6 +17,7 @@ class MailMsg:
     :param subject: email subject header
     :param recipients: list of email addresses
     :param body: plain text message
+    :param template_body: Data to pass into chosen Jinja2 template
     :param html: HTML message
     :param subtype: type of body parameter - "plain" or "html". Ignored if
     the html parameter is explicitly specified
@@ -92,10 +94,13 @@ class MailMsg:
         if self.body:
             self.message.attach(self._mimetext(self.body))
 
-        if self.template_body:
+        if self.template_body or self.body:
             if not self.html and self.subtype == 'html':
-                self.message.attach(self._mimetext(self.template_body, self.subtype))
-            else:
+                if self.body:
+                    warnings.warn("Use ``template_body`` instead of ``body`` to pass data into Jinja2 template",
+                                  DeprecationWarning)
+                self.message.attach(self._mimetext(self.template_body or self.body, self.subtype))
+            elif self.template_body:
                 raise ValueError("tried to send jinja2 template and html")
         elif self.html:
             self.message.attach(self._mimetext(self.html, "html"))

--- a/fastapi_mail/msg.py
+++ b/fastapi_mail/msg.py
@@ -94,7 +94,7 @@ class MailMsg:
 
         if self.template_body:
             if not self.html and self.subtype == 'html':
-                self.message.attach(self._mimetext(self.body, self.subtype))
+                self.message.attach(self._mimetext(self.template_body, self.subtype))
             else:
                 raise ValueError("tried to send jinja2 template and html")
         elif self.html:

--- a/fastapi_mail/msg.py
+++ b/fastapi_mail/msg.py
@@ -93,12 +93,11 @@ class MailMsg:
             self.message.attach(self._mimetext(self.body))
 
         if self.template_body:
-            if not self.html and self.subtype:
+            if not self.html and self.subtype == 'html':
                 self.message.attach(self._mimetext(self.body, self.subtype))
             else:
                 raise ValueError("tried to send jinja2 template and html")
-
-        if self.html:
+        elif self.html:
             self.message.attach(self._mimetext(self.html, "html"))
 
         if self.attachments:

--- a/fastapi_mail/schemas.py
+++ b/fastapi_mail/schemas.py
@@ -61,6 +61,13 @@ class MessageSchema(BaseModel):
                     "attachments field type incorrect, must be UploadFile or path")
         return temp
 
+    @validator('subtype')
+    def validate_subtype(cls, value, values, config, field):
+        """Validate subtype field."""
+        if values['template_body']:
+            return 'html'
+        return value
+
 
 def validate_path(path):
     cur_dir = os.path.abspath(os.curdir)

--- a/fastapi_mail/schemas.py
+++ b/fastapi_mail/schemas.py
@@ -28,11 +28,12 @@ class MessageSchema(BaseModel):
     recipients: List[EmailStr]
     attachments: List[Any] = []
     subject: str = ""
-    body: Union[str, list, dict] = None
+    body: Optional[Union[str, list]] = None
+    template_body: Optional[dict] = None
     html: Optional[Union[str, List, Dict]] = None
     cc: List[EmailStr] = []
     bcc: List[EmailStr] = []
-    reply_to: Optional[List[EmailStr]] = []
+    reply_to: List[EmailStr] = []
     charset: str = "utf-8"
     subtype: Optional[str] = None
     multipart_subtype: MultipartSubtypeEnum = MultipartSubtypeEnum.mixed

--- a/fastapi_mail/schemas.py
+++ b/fastapi_mail/schemas.py
@@ -29,7 +29,7 @@ class MessageSchema(BaseModel):
     attachments: List[Any] = []
     subject: str = ""
     body: Optional[Union[str, list]] = None
-    template_body: Optional[dict] = None
+    template_body: Optional[Union[list, dict]] = None
     html: Optional[Union[str, List, Dict]] = None
     cc: List[EmailStr] = []
     bcc: List[EmailStr] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-import os
+from pathlib import Path
+
 import pytest
 import fakeredis.aioredis
 from fastapi_mail.email_utils import DefaultChecker
@@ -24,8 +25,8 @@ async def redis_checker(scope="redis_config"):
 
 @pytest.fixture(autouse=True)
 def mail_config():
-    directory = os.getcwd()
-    html  = directory + "/files"
+    home: Path = Path(__file__).parent.parent
+    html = home / "files"
     env = {
         "MAIL_USERNAME": "example@test.com",
         "MAIL_PASSWORD":"strong",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from fastapi_mail import FastMail, MessageSchema, ConnectionConfig
 
@@ -20,20 +19,57 @@ async def test_connection(mail_config):
 
 @pytest.mark.asyncio
 async def test_html_message(mail_config):
-
-    directory = os.getcwd()
-    html = directory + "/files"
-
-    msg = MessageSchema(subject="testing",
-                        recipients=["to@example.com"],
-
-                        body="html test")
+    sender = f"{mail_config['MAIL_FROM_NAME']} <{mail_config['MAIL_FROM']}>"
+    subject = 'testing'
+    to = "to@example.com"
+    msg = MessageSchema(subject=subject,
+                        recipients=[to],
+                        html="html test")
     conf = ConnectionConfig(**mail_config)
     fm = FastMail(conf)
 
-    await fm.send_message(message=msg, template_name="test.html")
+    with fm.record_messages() as outbox:
+        await fm.send_message(message=msg)
 
-    assert msg.subtype == "html"
+        assert len(outbox) == 1
+        mail = outbox[0]
+        assert mail['To'] == to
+        assert mail['From'] == sender
+        assert mail['Subject'] == subject
+        assert not msg.subtype
+    assert msg.html == 'html test'
+
+
+@pytest.mark.asyncio
+async def test_jinja_message(mail_config):
+    sender = f"{mail_config['MAIL_FROM_NAME']} <{mail_config['MAIL_FROM']}>"
+    subject = 'testing'
+    to = "to@example.com"
+    persons = [
+        {"name": "Andrej"},
+        {"name": "Mark"},
+        {"name": "Thomas"},
+        {"name": "Lucy", },
+        {"name": "Robert"},
+        {"name": "Dragomir"}
+    ]
+    msg = MessageSchema(subject=subject,
+                        recipients=[to],
+                        template_body=persons,
+                        subtype='html')
+    conf = ConnectionConfig(**mail_config)
+    fm = FastMail(conf)
+
+    with fm.record_messages() as outbox:
+        await fm.send_message(message=msg, template_name='email.html')
+
+        assert len(outbox) == 1
+        mail = outbox[0]
+        assert mail['To'] == to
+        assert mail['From'] == sender
+        assert mail['Subject'] == subject
+    assert msg.subtype == 'html'
+    assert msg.template_body == '\n<p>\n    \n    Andrej\n\n    Mark\n\n    Thomas\n\n    Lucy\n\n    Robert\n\n    Dragomir\n\n</p>\n'
 
 
 @pytest.mark.asyncio
@@ -48,52 +84,12 @@ async def test_send_msg(mail_config):
     fm = FastMail(conf)
     fm.config.SUPPRESS_SEND = 1
     with fm.record_messages() as outbox:
-        await fm.send_message(message=msg, template_name="test.html")
+        await fm.send_message(message=msg)
 
         assert len(outbox) == 1
         assert outbox[0]["subject"] == "testing"
         assert outbox[0]["from"] == sender
         assert outbox[0]["To"] == "to@example.com"
-
-
-@pytest.mark.asyncio
-async def test_html_message_with_body(mail_config):
-    persons = [
-        {"name": "Andrej"},
-        {"name": "Mark"},
-        {"name": "Thomas"},
-        {"name": "Lucy", },
-        {"name": "Robert"},
-        {"name": "Dragomir"}
-    ]
-
-    directory = os.getcwd()
-    html = directory + "/files"
-
-    msg = MessageSchema(subject="testing",
-                        recipients=["to@example.com"],
-                        body=persons)
-    conf = ConnectionConfig(**mail_config)
-    fm = FastMail(conf)
-
-    await fm.send_message(message=msg, template_name="email.html")
-    assert msg.body == """
-<p>
-    
-    Andrej
-
-    Mark
-
-    Thomas
-
-    Lucy
-
-    Robert
-
-    Dragomir
-
-</p>
-"""
 
 
 @pytest.mark.asyncio
@@ -107,16 +103,16 @@ async def test_html_message_with_html(mail_config):
         {"name": "Dragomir"}
     ]
 
-    directory = os.getcwd()
-    html = directory + "/files"
-
     msg = MessageSchema(subject="testing",
                         recipients=["to@example.com"],
-                        html=persons)
+                        template_body=persons,
+                        subtype='html')
     conf = ConnectionConfig(**mail_config)
     fm = FastMail(conf)
     await fm.send_message(message=msg, template_name="email.html")
-    assert msg.html == """
+    assert not msg.body
+    assert not msg.html
+    assert msg.template_body == """
 <p>
     
     Andrej

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -16,6 +16,11 @@ async def test_connection(mail_config):
 
     await fm.send_message(message)
 
+    assert message.body == 'test'
+    assert message.subtype == 'plain'
+    assert not message.template_body
+    assert not message.html
+
 
 @pytest.mark.asyncio
 async def test_html_message(mail_config):
@@ -91,7 +96,29 @@ async def test_send_msg(mail_config):
 
 
 @pytest.mark.asyncio
-async def test_html_message_with_html(mail_config):
+async def test_send_msg_with_subtype(mail_config):
+    msg = MessageSchema(subject="testing",
+                        recipients=["to@example.com"],
+                        body="<p html test </p>",
+                        subtype='html')
+
+    sender = f"{mail_config['MAIL_FROM_NAME']} <{mail_config['MAIL_FROM']}>"
+    conf = ConnectionConfig(**mail_config)
+    fm = FastMail(conf)
+    fm.config.SUPPRESS_SEND = 1
+    with fm.record_messages() as outbox:
+        await fm.send_message(message=msg)
+
+        assert len(outbox) == 1
+        assert outbox[0]["subject"] == "testing"
+        assert outbox[0]["from"] == sender
+        assert outbox[0]["To"] == "to@example.com"
+    assert msg.body == "<p html test </p>"
+    assert msg.subtype == 'html'
+
+
+@pytest.mark.asyncio
+async def test_jinja_message_with_html(mail_config):
     persons = [
         {"name": "Andrej"},
         {"name": "Mark"},
@@ -103,26 +130,12 @@ async def test_html_message_with_html(mail_config):
 
     msg = MessageSchema(subject="testing",
                         recipients=["to@example.com"],
-                        template_body=persons)
+                        template_body=persons,
+                        html='test html')
     conf = ConnectionConfig(**mail_config)
     fm = FastMail(conf)
-    await fm.send_message(message=msg, template_name="email.html")
+
+    with pytest.raises(ValueError):
+        await fm.send_message(message=msg, template_name="email.html")
+    assert msg.template_body == persons
     assert not msg.body
-    assert not msg.html
-    assert msg.template_body == """
-<p>
-    
-    Andrej
-
-    Mark
-
-    Thomas
-
-    Lucy
-
-    Robert
-
-    Dragomir
-
-</p>
-"""

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -55,8 +55,7 @@ async def test_jinja_message(mail_config):
     ]
     msg = MessageSchema(subject=subject,
                         recipients=[to],
-                        template_body=persons,
-                        subtype='html')
+                        template_body=persons)
     conf = ConnectionConfig(**mail_config)
     fm = FastMail(conf)
 
@@ -76,7 +75,6 @@ async def test_jinja_message(mail_config):
 async def test_send_msg(mail_config):
     msg = MessageSchema(subject="testing",
                         recipients=["to@example.com"],
-
                         body="html test")
 
     sender = f"{mail_config['MAIL_FROM_NAME']} <{mail_config['MAIL_FROM']}>"
@@ -105,8 +103,7 @@ async def test_html_message_with_html(mail_config):
 
     msg = MessageSchema(subject="testing",
                         recipients=["to@example.com"],
-                        template_body=persons,
-                        subtype='html')
+                        template_body=persons)
     conf = ConnectionConfig(**mail_config)
     fm = FastMail(conf)
     await fm.send_message(message=msg, template_name="email.html")


### PR DESCRIPTION
Hi,

I've been using this library for a few weeks and ran into some issues with the jinja2 integration.

1) if ConnectionConfig is not instantiated in project parent directory the template validator silently fails and returns None. This results in very confusing error messages because user is not notified about it.

#### This has been improved so there is proper directory validation and template engine creation is done separately via a method.

2) There are 3 ways to send data with MessageSchema - via body (no jinja2), html or body (with jinja2). The combination of this with the subtype argument is pretty confusing because it is not very well documented so sometimes emails end up looking very differently from what we would expect.

#### Created a separate jinja2 argument (template_body) so user knows which argument to use whether they're using jinja2 or not.