### PR TITLE
Added validate certificate config, supported by aiosmtplib

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ conf = ConnectionConfig(
     MAIL_SERVER = "your mail server",
     MAIL_TLS = True,
     MAIL_SSL = False,
-    USE_CREDENTIALS = True
+    USE_CREDENTIALS = True,
+    VALIDATE_CERTS = True
 )
 
 app = FastAPI()

--- a/docs/example.md
+++ b/docs/example.md
@@ -33,7 +33,8 @@ conf = ConnectionConfig(
     MAIL_FROM_NAME="Desired Name"
     MAIL_TLS = True,
     MAIL_SSL = False,
-    USE_CREDENTIALS = True
+    USE_CREDENTIALS = True,
+    VALIDATE_CERTS = True
 )
 
 app = FastAPI()

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,6 +34,7 @@ class has following attributes
 -  TEMPLATE_FOLDER: If you are using jinja2, specify template folder name
 -  SUPPRESS_SEND:  To mock sending out mail, defaults 0.
 -  USE_CREDENTIALS: Defaults to `True`. However it enables users to choose whether or not to login to their SMTP server.
+-  VALIDATE_CERTS: Defaults to `True`. It enables to choose whether to verify the mail server's certificate
 
 
 

--- a/fastapi_mail/config.py
+++ b/fastapi_mail/config.py
@@ -20,6 +20,7 @@ class ConnectionConfig(Settings):
     TEMPLATE_FOLDER: Any = None
     SUPPRESS_SEND: conint(gt=-1, lt=2) = 0
     USE_CREDENTIALS: bool = True
+    VALIDATE_CERTS: bool = True
 
     @validator("TEMPLATE_FOLDER", pre=True)
     def create_template_engine(cls, v):

--- a/fastapi_mail/connection.py
+++ b/fastapi_mail/connection.py
@@ -33,7 +33,8 @@ class Connection:
                 hostname=self.settings.get("MAIL_SERVER"),
                 port=self.settings.get("MAIL_PORT"),
                 use_tls=self.settings.get("MAIL_SSL"),
-                start_tls=self.settings.get("MAIL_TLS")
+                start_tls=self.settings.get("MAIL_TLS"),
+                validate_certs=self.settings.get("VALIDATE_CERTS")
             )
             
             if not self.settings.get("SUPPRESS_SEND"): # for test environ

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,8 +38,8 @@ def mail_config():
         "MAIL_DEBUG": 0,
         "SUPPRESS_SEND": 1,
         "USE_CREDENTIALS": False,
+        "VALIDATE_CERTS": False,
         "TEMPLATE_FOLDER": html,
-
     }
 
     yield env


### PR DESCRIPTION
- Added a argument validate_cert which provides option whether to validate mail server certificate
- This is a workaround for issue where the mail server has a self signed certificate