### PR TITLE
remove TEMPLATE_FOLDER validation because Pydantic DirectoryPath already does that…

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -26,10 +26,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        
-        pip install setuptools wheel jinja2>=2.11.2 blinker>=1.4 twine fastapi>=0.61.2 aioredis>=1.3.1 httpx>=0.16.1 starlette pydantic>=1.7.1 aiosmtplib>=1.1.4 python-multipart>=0.0.5 email-validator>=1.1.1 fakeredis>=1.4.5
+
+        pip install setuptools wheel jinja2>=2.11.2 blinker>=1.4 twine fastapi>=0.61.2 aioredis>=2.0.0 httpx>=0.16.1 starlette pydantic>=1.7.1 aiosmtplib>=1.1.4 python-multipart>=0.0.5 email-validator>=1.1.1 fakeredis>=1.4.5
         python -c "import sys; print(sys.version)"
-        
+
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/fastapi_mail/email_utils/email_check.py
+++ b/fastapi_mail/email_utils/email_check.py
@@ -55,7 +55,7 @@ class DefaultChecker(AbstractEmailChecker):
         :param source(optional): source for collected email data.
         :param db_provider: switch to redis
 
-        example: 
+        example:
             from email_utils import DefaultChecker
             import asyncio
 
@@ -104,7 +104,7 @@ class DefaultChecker(AbstractEmailChecker):
         if not self.redis_enabled:
             raise DBProvaiderError(self.redis_error_msg)
         if not hasattr(self, "redis_client"):
-            self.redis_client = await aioredis.create_redis_pool(
+            self.redis_client = await aioredis.from_url(
                 address=f"{self.redis_host}:{self.redis_port}",
                 db=self.redis_db,
                 password=self.redis_pass,
@@ -288,14 +288,14 @@ class WhoIsXmlApi:
         :param token: token you can get from this https://www.whoisxmlapi.com/ link
         :param email: email for checking
 
-        example: 
+        example:
             from email_utils import WhoIsXmlApi
 
             who_is = WhoIsXmlApi(token="Your access token", email = "your@mailaddress.com")
 
             print(who_is.smtp_check_())  # check smtp server
             print(who_is.is_dispasoble()) # check email is disposable or not
-            print(who_is.check_mx_record()) # check domain mx records 
+            print(who_is.check_mx_record()) # check domain mx records
             print(who_is.free_check()) # check email domain is free or not
         ```
     """
@@ -341,24 +341,24 @@ class WhoIsXmlApi:
 
     def catch_all_check(self):
         """
-        Tells you whether or not this mail server has a “catch-all” address. 
-        This refers to a special type of address that can receive emails for any number of non-existent email addresses 
-        under a particular domain. Catch-all addresses are common in businesses where if you send an email to test@hi.com and 
-        another email to non-existent test2@hi.com, both of those emails will go into the same inbox. 
+        Tells you whether or not this mail server has a “catch-all” address.
+        This refers to a special type of address that can receive emails for any number of non-existent email addresses
+        under a particular domain. Catch-all addresses are common in businesses where if you send an email to test@hi.com and
+        another email to non-existent test2@hi.com, both of those emails will go into the same inbox.
         Possible values are 'true' or 'false'. May be 'null' for invalid or non-existing emails.
 
         """
         return self.catch_all
 
     def smtp_check_(self):
-        """  
-        Checks if the email address exists and 
-        can receive emails by using SMTP connection and 
-        email-sending emulation techniques. 
-        This value will be 'true' if the email address exists and 
-        can receive email over SMTP, and 'false' if the email address does not exist 
-        on the target SMTP server or temporarily couldn't receive messages. 
-        The value will be null if the SMTP request could not be completed, 
+        """
+        Checks if the email address exists and
+        can receive emails by using SMTP connection and
+        email-sending emulation techniques.
+        This value will be 'true' if the email address exists and
+        can receive email over SMTP, and 'false' if the email address does not exist
+        on the target SMTP server or temporarily couldn't receive messages.
+        The value will be null if the SMTP request could not be completed,
         mailbox verification is not supported on the target mailbox provider, or not applicable.
 
         """
@@ -366,8 +366,8 @@ class WhoIsXmlApi:
 
     def is_dispasoble(self):
         """
-        Tells you whether or not the email address is disposable (created via a service like Mailinator). 
-        This helps you check for abuse. This value will be 'false' if the email is not disposable, and 'true' otherwise. 
+        Tells you whether or not the email address is disposable (created via a service like Mailinator).
+        This helps you check for abuse. This value will be 'false' if the email is not disposable, and 'true' otherwise.
         May be 'null' for invalid or non-existing emails.
 
         """
@@ -375,15 +375,15 @@ class WhoIsXmlApi:
 
     def check_mx_record(self):
         """
-        Mail servers list. 
-        May be absent for invalid or non-existing emails.    
+        Mail servers list.
+        May be absent for invalid or non-existing emails.
         """
         return self.mx_records
 
     def check_dns(self):
         """
-        Ensures that the domain in the email address, eg: gmail.com, is a valid domain. 
-        This value will be 'true' if the domain is good and 'false' otherwise. 
+        Ensures that the domain in the email address, eg: gmail.com, is a valid domain.
+        This value will be 'true' if the domain is good and 'false' otherwise.
         May be 'null' for invalid or non-existing emails.
 
         """
@@ -391,8 +391,8 @@ class WhoIsXmlApi:
 
     def check_free(self):
         """
-        Check to see if the email address is from a free email provider like Gmail or not. 
-        This value will be 'false' if the email address is not free, and 'true' otherwise. 
+        Check to see if the email address is from a free email provider like Gmail or not.
+        This value will be 'false' if the email address is not free, and 'true' otherwise.
         May be 'null' for invalid or non-existing emails.
 
         """

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     license='MIT',
     url="https://github.com/sabuhish/fastapi-mail",
-    install_requires=["fastapi>=0.61.2",'jinja2>=2.11.2',"aiosmtplib>=1.1.5","python-multipart>=0.0.5", "pydantic>=1.7.1","email-validator>=1.1.1","aioredis>=1.3.1","httpx>=0.16.1","blinker>=1.4","fakeredis>=1.4.5"],
+    install_requires=["fastapi>=0.61.2",'jinja2>=2.11.2',"aiosmtplib>=1.1.5","python-multipart>=0.0.5", "pydantic>=1.7.1","email-validator>=1.1.1","aioredis>=2.0.0","httpx>=0.16.1","blinker>=1.4","fakeredis>=1.4.5"],
     tests_require=test_dependencies,
     test_suite="tests",
     dependency_links=["https://github.com/cole/aiosmtplib/archive/e8e5ea5acb959f374909dd7961fab865473dbc80.zip#egg=aiosmtplib-1.1.4+gite8e5ea5"],
@@ -29,7 +29,7 @@ setuptools.setup(
         "extra":[
             "blinker>=1.4"
         ]
-        
+
     },
     platforms=['any'],
     packages=setuptools.find_packages(),
@@ -44,5 +44,3 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
 )
-
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def default_checker():
 @pytest.mark.asyncio
 async def redis_checker(scope="redis_config"):
     test = DefaultChecker(db_provider="redis")
-    test.redis_client = await  fakeredis.aioredis.create_redis_pool(encoding="UTF-8")
+    test.redis_client = await fakeredis.aioredis.from_url(encoding="UTF-8")
     await test.init_redis()
     yield test
     await test.redis_client.flushall()

--- a/tests/requirements.testing.txt
+++ b/tests/requirements.testing.txt
@@ -5,4 +5,4 @@ Jinja2==2.11.3
 starlette==0.13.8
 email-validator==1.1.1
 httpx==0.16.1
-aioredis==1.3.1
+aioredis>=2.0.0


### PR DESCRIPTION
`fastapi-mail` `ConnectionConfig` does not need to check for a valid `TEMPLATE_FOLDER` value since `pydantic`'s `DirectoryPath` already does that: https://pydantic-docs.helpmanual.io/usage/types/#pydantic-types