### PR TITLE
Implemented Custom Headers to Mails

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Thanks goes to these wonderful people ([🚧](https://sabuhish.github.io/fastapi
     <td align="center"><a href="https://github.com/LLYX"><img src="https://avatars1.githubusercontent.com/u/10430633" width="100px;" alt=""/><br /><sub><b>Leon Xu</b></sub></a><br /><a href="#maintenance-tbenning" title="Maintenance">🚧</a></td>
     <td align="center"><a href="https://github.com/gabrielponto"><img src="https://avatars.githubusercontent.com/u/7227328" width="100px;" alt=""/><br /><sub><b>Gabriel Oliveira</b></sub></a><br /><a href="https://github.com/sabuhish/fastapi-mail/" title="Documentation">📖</a> <a href="#maintenance-jakebolam" title="Maintenance">🚧</a></td>
     <td align="center"><a href="https://github.com/maestro-1"><img src="https://avatars0.githubusercontent.com/u/40833254" width="100px;" alt=""/><br /><sub><b>Onothoja Marho</b></sub></a><br /><a href="https://github.com/sabuhish/fastapi-mail/" title="Documentation">📖</a> <a  href="#maintenance-jakebolam"  title="Maintenance">🚧</a> <a href="#tool-jfmengels" title="Tools">🔧</a></td>
+
   </tr>
  <tr>
     <td align="center"><a href="https://github.com/TheTimKiely"><img src="https://avatars1.githubusercontent.com/u/34795732" width="100px;" alt=""/><br /><sub><b>Tim Kiely</b></sub></a><br /><a href="#maintenance-tbenning" title="Maintenance">🚧</a></td>

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Thanks goes to these wonderful people ([🚧](https://sabuhish.github.io/fastapi
     <td align="center"><a href="https://github.com/LLYX"><img src="https://avatars1.githubusercontent.com/u/10430633" width="100px;" alt=""/><br /><sub><b>Leon Xu</b></sub></a><br /><a href="#maintenance-tbenning" title="Maintenance">🚧</a></td>
     <td align="center"><a href="https://github.com/gabrielponto"><img src="https://avatars.githubusercontent.com/u/7227328" width="100px;" alt=""/><br /><sub><b>Gabriel Oliveira</b></sub></a><br /><a href="https://github.com/sabuhish/fastapi-mail/" title="Documentation">📖</a> <a href="#maintenance-jakebolam" title="Maintenance">🚧</a></td>
     <td align="center"><a href="https://github.com/maestro-1"><img src="https://avatars0.githubusercontent.com/u/40833254" width="100px;" alt=""/><br /><sub><b>Onothoja Marho</b></sub></a><br /><a href="https://github.com/sabuhish/fastapi-mail/" title="Documentation">📖</a> <a  href="#maintenance-jakebolam"  title="Maintenance">🚧</a> <a href="#tool-jfmengels" title="Tools">🔧</a></td>
-
   </tr>
  <tr>
     <td align="center"><a href="https://github.com/TheTimKiely"><img src="https://avatars1.githubusercontent.com/u/34795732" width="100px;" alt=""/><br /><sub><b>Tim Kiely</b></sub></a><br /><a href="#maintenance-tbenning" title="Maintenance">🚧</a></td>

--- a/docs/example.md
+++ b/docs/example.md
@@ -211,6 +211,19 @@ message = MessageSchema(
 fm = FastMail(conf)
 await fm.send_message(message)
 ```
+
+### Adding custom SMTP headers
+```python
+message = MessageSchema(
+    subject='Fastapi-Mail module',
+    recipients=recipients,
+    headers={"your custom header": "your custom value"}
+)
+
+fm = FastMail(conf)
+await fm.send_message(message)
+```
+
 ##  Guide for email utils
 
 The utility allows you to check temporary email addresses, you can block any email or domain. 

--- a/fastapi_mail/msg.py
+++ b/fastapi_mail/msg.py
@@ -29,7 +29,7 @@ class MailMsg:
     :param multipart_subtype: MultipartSubtypeEnum instance. Determines the
     nature of the parts of the message and their relationship to each other
     according to the MIME standard
-    :param: headers: list of custom SMTP headers
+    :param: headers: dict of custom SMTP headers
     """
 
     def __init__(self, **entries):

--- a/fastapi_mail/msg.py
+++ b/fastapi_mail/msg.py
@@ -29,6 +29,7 @@ class MailMsg:
     :param multipart_subtype: MultipartSubtypeEnum instance. Determines the
     nature of the parts of the message and their relationship to each other
     according to the MIME standard
+    :param: headers: list of custom SMTP headers
     """
 
     def __init__(self, **entries):
@@ -111,6 +112,10 @@ class MailMsg:
 
         if self.attachments:
             await self.attach_file(self.message, self.attachments)
+
+        if self.headers:
+            for header_name, header_content in self.headers.items():
+                self.message.add_header(header_name, header_content)
 
         return self.message
 

--- a/fastapi_mail/schemas.py
+++ b/fastapi_mail/schemas.py
@@ -40,6 +40,7 @@ class MessageSchema(BaseModel):
     charset: str = 'utf-8'
     subtype: Optional[str] = None
     multipart_subtype: MultipartSubtypeEnum = MultipartSubtypeEnum.mixed
+    headers: Optional[Dict] = None
 
     @validator('attachments')
     def validate_file(cls, v):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -78,6 +78,20 @@ async def test_attachement_message(mail_config):
 
 
 @pytest.mark.asyncio
+async def test_message_with_headers(mail_config):
+    subject = 'testing'
+    to = 'to@example.com'
+    msg = MessageSchema(subject=subject, recipients=[to], headers={"foo": "bar"})
+    conf = ConnectionConfig(**mail_config)
+    fm = FastMail(conf)
+
+    with fm.record_messages() as outbox:
+        await fm.send_message(message=msg)
+        mail = outbox[0]
+        assert ('foo', 'bar') in mail._headers
+
+
+@pytest.mark.asyncio
 async def test_attachement_message_with_headers(mail_config):
     directory = os.getcwd()
     attachement = directory + '/files/attachement.txt'

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -114,6 +114,13 @@ def test_multipart_subtype():
     assert message.multipart_subtype == MultipartSubtypeEnum.mixed
 
 
+def test_headers():
+    message = MessageSchema(
+        subject='test subject', recipients=['to@example.com'], headers={"foo": "bar"}
+    )
+    assert message.headers == {"foo": "bar"}
+
+
 @pytest.mark.asyncio
 async def test_msgid_header():
     message = MessageSchema(


### PR DESCRIPTION
## What? ✨

Allows users to add custom SMTP headers to email requests

Related to this [issue raised on Custom SMTP Headers](https://github.com/sabuhish/fastapi-mail/issues/116)

## Why? 📝

Some email providers allow users to attach custom SMTP headers for specific operations, such as custom ids to track the status of mails with webhooks. I thought this would be a great little feature to add to fastapi-mail.

## How? 🔧

- Added optional headers dict to the `MessageSchema` pydantic model.
- Using `add_headers` function from python emails, attached the key and value of each header in the dict to the message.
- Updated tests to reflect the changes.