### PR TITLE
Fix README.md send html example bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ async def simple_send(email: EmailSchema) -> JSONResponse:
     message = MessageSchema(
         subject="Fastapi-Mail module",
         recipients=email.dict().get("email"),  # List of recipients, as many as you can pass 
-        body=html,
+        html=html,
         subtype="html"
         )
 


### PR DESCRIPTION
Hi Sabuhi:
It seems like something wrong about sending html with body args in README.md example,
the mail will display the error format (the encoded content and the content before encoding) when they send html with body args,
plz check this issue, thanks

BR, Jimmy