### PR TITLE
Fix typos

### DIFF
--- a/fastapi_mail/email_utils/email_check.py
+++ b/fastapi_mail/email_utils/email_check.py
@@ -30,7 +30,7 @@ class AbstractEmailChecker(ABC):
         pass
 
     @abstractmethod
-    async def is_dispasoble(self, email: str):
+    async def is_disposable(self, email: str):
         pass
 
     @abstractmethod
@@ -231,7 +231,7 @@ class DefaultChecker(AbstractEmailChecker):
             self.TEMP_EMAIL_DOMAINS.remove(domain)
         return True
 
-    async def is_dispasoble(self, email: str) -> bool:
+    async def is_disposable(self, email: str) -> bool:
         """Check email address is temporary or not"""
         if self.validate_email(email):
             _, domain = email.split('@')
@@ -318,7 +318,7 @@ class WhoIsXmlApi:
         who_is = WhoIsXmlApi(token="Your access token", email = "your@mailaddress.com")
 
         print(who_is.smtp_check_())  # check smtp server
-        print(who_is.is_dispasoble()) # check email is disposable or not
+        print(who_is.is_disposable()) # check email is disposable or not
         print(who_is.check_mx_record()) # check domain mx records
         print(who_is.free_check()) # check email domain is free or not
     ```
@@ -387,7 +387,7 @@ class WhoIsXmlApi:
         """
         return self.smtp_check
 
-    def is_dispasoble(self):
+    def is_disposable(self):
         """
         Tells you whether or not the email address is disposable (created via a service like
         Mailinator).

--- a/fastapi_mail/example.py
+++ b/fastapi_mail/example.py
@@ -14,6 +14,6 @@ loop.run_until_complete(checker.close_connections())
 who_is = WhoIsXmlApi(token='Your access token', email='your@mailaddress.com')
 
 print(who_is.smtp_check_())  # check smtp server
-print(who_is.is_dispasoble())   # check email is disposable or not
+print(who_is.is_disposable())   # check email is disposable or not
 print(who_is.check_mx_record())   # check domain mx records
 print(who_is.free_check)   # check email domain is free or not

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -12,7 +12,7 @@ async def test_default_checker(default_checker):
     email = 'tural_m@hotmail.com'
     domain = email.split('@')[-1]
 
-    assert await default_checker.is_dispasoble(email) is False
+    assert await default_checker.is_disposable(email) is False
     assert await default_checker.is_blocked_domain(domain) is False
     assert await default_checker.is_blocked_address(email) is False
     assert await default_checker.check_mx_record(domain) is True
@@ -22,7 +22,7 @@ async def test_default_checker(default_checker):
 
     await default_checker.add_temp_domain([domain])
 
-    assert await default_checker.is_dispasoble(email) is True
+    assert await default_checker.is_disposable(email) is True
     assert await default_checker.is_blocked_domain(domain) is False
     assert await default_checker.is_blocked_address(email) is False
     assert await default_checker.check_mx_record(domain) is True

--- a/tests/test_redis_config.py
+++ b/tests/test_redis_config.py
@@ -10,14 +10,14 @@ async def test_redis_checker(redis_checker):
     email = 'test_me@hotmail.com'
     domain = email.split('@')[-1]
 
-    assert await redis_checker.is_dispasoble(email) is False
+    assert await redis_checker.is_disposable(email) is False
     assert await redis_checker.is_blocked_domain(domain) is False
     assert await redis_checker.is_blocked_address(email) is False
     assert await redis_checker.check_mx_record(domain) is True
 
     await redis_checker.add_temp_domain([domain])
 
-    assert await redis_checker.is_dispasoble(email) is True
+    assert await redis_checker.is_disposable(email) is True
     assert await redis_checker.is_blocked_domain(domain) is False
     assert await redis_checker.is_blocked_address(email) is False
     assert await redis_checker.check_mx_record(domain) is True


### PR DESCRIPTION
Correct spelling of "disposable" from instances spelled "dispasoble".