### PR TITLE
115 multipart html and plain text emails

### DIFF
--- a/fastapi_mail/msg.py
+++ b/fastapi_mail/msg.py
@@ -100,7 +100,7 @@ class MailMsg:
         else:
             flipped_subtype = "plain"
         tmpmsg.attach(self._mimetext(self.alternative_body, flipped_subtype))
-        message = MIMEMultipart(self.multipart_subtype.value)
+        message = MIMEMultipart(MultipartSubtypeEnum.related.value)
         message.set_charset(self.charset)
         message.attach(tmpmsg)
         return message

--- a/fastapi_mail/msg.py
+++ b/fastapi_mail/msg.py
@@ -19,6 +19,7 @@ class MailMsg:
     :param: subject: Email subject header
     :param: recipients: List of email addresses
     :param: body: Plain text message or HTML message
+    :param: alternative_body: Plain text message or HTML message
     :param: template_body: Data to pass into chosen Jinja2 template
     :param: subtype: MessageType class. Type of body parameter, either "plain" or "html"
     :param: sender: Email sender address

--- a/fastapi_mail/schemas.py
+++ b/fastapi_mail/schemas.py
@@ -3,7 +3,7 @@ from enum import Enum
 from mimetypes import MimeTypes
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, EmailStr, validator
+from pydantic import BaseModel, EmailStr, validator, root_validator
 from starlette.datastructures import Headers, UploadFile
 
 from fastapi_mail.errors import WrongFile

--- a/fastapi_mail/schemas.py
+++ b/fastapi_mail/schemas.py
@@ -3,7 +3,7 @@ from enum import Enum
 from mimetypes import MimeTypes
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, EmailStr, validator
+from pydantic import BaseModel, EmailStr, validator, root_validator
 from starlette.datastructures import UploadFile
 
 from fastapi_mail.errors import WrongFile
@@ -37,6 +37,7 @@ class MessageSchema(BaseModel):
     attachments: List[Union[UploadFile, Dict, str]] = []
     subject: str = ""
     body: Optional[Union[str, list]] = None
+    alternative_body: Optional[str] = None
     template_body: Optional[Union[list, dict, str]] = None
     cc: List[EmailStr] = []
     bcc: List[EmailStr] = []
@@ -87,6 +88,18 @@ class MessageSchema(BaseModel):
         if values["template_body"]:
             return MessageType.html
         return value
+
+    @root_validator
+    def validate_alternative_body(cls, values):
+        """
+        Validate alternative_body field
+        """
+        if (
+            values["multipart_subtype"] != MultipartSubtypeEnum.alternative
+            and values["alternative_body"]
+        ):
+            values["alternative_body"] = None
+        return values
 
     class Config:
         arbitrary_types_allowed = True

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -87,10 +87,7 @@ async def test_attachement_message(mail_config):
 
         assert len(outbox) == 1
         assert mail._payload[1].get_content_maintype() == "application"
-        assert (
-            mail._payload[1].__dict__.get("_headers")[0][1]
-            == "application/octet-stream"
-        )
+        assert mail._payload[1].__dict__.get("_headers")[0][1] == "application/octet-stream"
 
 
 @pytest.mark.asyncio
@@ -152,20 +149,16 @@ async def test_attachement_message_with_headers(mail_config):
 
         assert len(outbox) == 1
         mail = outbox[0]
-        assert mail._payload[1].get_content_maintype() == msg.attachments[0][1].get(
-            "mime_type"
-        )
-        assert mail._payload[1].get_content_subtype() == msg.attachments[0][1].get(
-            "mime_subtype"
-        )
+        assert mail._payload[1].get_content_maintype() == msg.attachments[0][1].get("mime_type")
+        assert mail._payload[1].get_content_subtype() == msg.attachments[0][1].get("mime_subtype")
 
         assert mail._payload[1].__dict__.get("_headers")[0][1] == "image/png"
-        assert mail._payload[1].__dict__.get("_headers")[3][1] == msg.attachments[0][
-            1
-        ].get("headers").get("Content-ID")
-        assert mail._payload[1].__dict__.get("_headers")[4][1] == msg.attachments[0][
-            1
-        ].get("headers").get("Content-Disposition")
+        assert mail._payload[1].__dict__.get("_headers")[3][1] == msg.attachments[0][1].get(
+            "headers"
+        ).get("Content-ID")
+        assert mail._payload[1].__dict__.get("_headers")[4][1] == msg.attachments[0][1].get(
+            "headers"
+        ).get("Content-Disposition")
 
         assert (
             mail._payload[2].__dict__.get("_headers")[3][1] == "attachment; "
@@ -189,9 +182,7 @@ async def test_jinja_message_list(mail_config):
     fm = FastMail(conf)
 
     with fm.record_messages() as outbox:
-        await fm.send_message(
-            message=msg, template_name="array_iteration_jinja_template.html"
-        )
+        await fm.send_message(message=msg, template_name="array_iteration_jinja_template.html")
 
         assert len(outbox) == 1
         mail = outbox[0]
@@ -290,9 +281,7 @@ async def test_jinja_message_with_html(mail_config):
     )
     conf = ConnectionConfig(**mail_config)
     fm = FastMail(conf)
-    await fm.send_message(
-        message=msg, template_name="array_iteration_jinja_template.html"
-    )
+    await fm.send_message(message=msg, template_name="array_iteration_jinja_template.html")
 
     assert msg.template_body == ("\n    \n    \n        Andrej\n    \n\n")
 
@@ -318,19 +307,58 @@ async def test_send_msg_with_alternative_body(mail_config):
         await fm.send_message(message=msg)
 
         mail = outbox[0]
+        assert len(outbox) == 1
+        body = mail._payload[0]
+        assert len(body._payload) == 2
+        assert body._headers[1][1] == 'multipart/alternative; charset="utf-8"'
+        assert mail["subject"] == "testing"
+        assert mail["from"] == sender
+        assert mail["To"] == "to@example.com"
 
-        print(mail._payload[1].__dict__)
-        print(mail._payload[0].__dict__)
-        assert 1 == 2
+        assert body._payload[0]._headers[0][1] == 'text/html; charset="utf-8"'
+        assert body._payload[1]._headers[0][1] == 'text/plain; charset="utf-8"'
+    assert msg.alternative_body == "Test data"
+    assert msg.multipart_subtype == MultipartSubtypeEnum.alternative
+
+
+@pytest.mark.asyncio
+async def test_send_msg_with_alternative_body_and_attachements(mail_config):
+    directory = os.getcwd()
+    text_file = directory + "/tests/txt_files/plain.txt"
+
+    with open(text_file, "w") as file:
+        file.write(CONTENT)
+
+    subject = "testing"
+    to = "to@example.com"
+    msg = MessageSchema(
+        subject=subject,
+        recipients=[to],
+        body="html test",
+        subtype="html",
+        attachments=[text_file],
+        alternative_body="plain test",
+        multipart_subtype="alternative",
+    )
+    sender = f"{mail_config['MAIL_FROM_NAME']} <{mail_config['MAIL_FROM']}>"
+    conf = ConnectionConfig(**mail_config)
+    fm = FastMail(conf)
+    fm.config.SUPPRESS_SEND = 1
+    with fm.record_messages() as outbox:
+        await fm.send_message(message=msg)
+
+        mail = outbox[0]
+
         assert len(outbox) == 1
-        assert mail._payload[1].get_content_maintype() == "plain"
-        assert (
-            mail._payload[1].__dict__.get("_headers")[0][1]
-            == "application/octet-stream"
-        )
-        assert len(outbox) == 1
-        assert outbox[0]["subject"] == "testing"
-        assert outbox[0]["from"] == sender
-        assert outbox[0]["To"] == "to@example.com"
-    assert msg.body == "<p Test data </p>"
-    assert msg.subtype == MessageType.html
+        body = mail._payload[0]
+        assert len(body._payload) == 2
+        assert body._headers[1][1] == 'multipart/alternative; charset="utf-8"'
+        assert mail["subject"] == "testing"
+        assert mail["from"] == sender
+        assert mail["To"] == "to@example.com"
+
+        assert body._payload[0]._headers[0][1] == 'text/html; charset="utf-8"'
+        assert body._payload[1]._headers[0][1] == 'text/plain; charset="utf-8"'
+
+        assert mail._payload[1].get_content_maintype() == "application"
+        assert mail._payload[1].__dict__.get("_headers")[0][1] == "application/octet-stream"

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -4,6 +4,7 @@ import pytest
 
 from fastapi_mail.msg import MailMsg
 from fastapi_mail.schemas import MessageSchema, MessageType, MultipartSubtypeEnum
+from pydantic.error_wrappers import ValidationError
 
 
 def test_initialize():
@@ -188,3 +189,26 @@ async def test_message_charset():
     msg_object = await msg._message("test@example.com")
     assert msg_object._charset is not None
     assert msg_object._charset == "utf-8"
+
+
+def test_message_with_alternative_body_but_wrong_multipart_subtype():
+    message = MessageSchema(
+        subject="test subject",
+        recipients=["test@gmail.com"],
+        body="test",
+        subtype=MessageType.plain,
+        alternative_body="alternative",
+    )
+    assert message.alternative_body == None
+
+
+def test_message_with_alternative_body():
+    message = MessageSchema(
+        subject="test subject",
+        recipients=["test@gmail.com"],
+        body="test",
+        subtype=MessageType.plain,
+        multipart_subtype=MultipartSubtypeEnum.alternative,
+        alternative_body="alternative",
+    )
+    assert message.alternative_body == "alternative"


### PR DESCRIPTION
This pull request solves #115 by adding an alternative body to the `MessageSchema` and implementing functionalities for adding the alternative body in the `MailMsg` class.
