### PR TITLE
Close attachments files passed to MessageSchema

### DIFF
--- a/fastapi_mail/msg.py
+++ b/fastapi_mail/msg.py
@@ -66,6 +66,7 @@ class MailMsg:
 
             part.set_payload(await file.read())
             encode_base64(part)
+            await file.close()
 
             if file_meta and "headers" in file_meta:
                 for header in file_meta["headers"].keys():


### PR DESCRIPTION
When enabling ` PYTHONTRACEMALLOC=1` I could see that when passing `attachments` files to `MessageSchema`, there are not closed

I receive a list of warnings
```
PYTHONTRACEMALLOC=1  python -W always -m pytest

tests/test_connection.py::test_attachement_message
tests/test_connection.py::test_attachement_message_with_headers
  /usr/lib/python3.8/threading.py:932: ResourceWarning: unclosed file <_io.BufferedReader name='/root/fastapi-mail/tests/txt_files/plain.txt'>
    self.run()
  
  Object allocated at:
    File "/usr/lib/python3.8/threading.py", line 932
      self.run()

tests/test_connection.py::test_attachement_message_with_headers
  /usr/lib/python3.8/asyncio/events.py:81: ResourceWarning: unclosed file <_io.BufferedReader name='/root/fastapi-mail/tests/txt_files/plain.txt'>
    self._context.run(self._callback, *self._args)
  
  Object allocated at:
    File "/usr/lib/python3.8/asyncio/events.py", line 81
      self._context.run(self._callback, *self._args)

tests/test_message.py::test_plain_message_with_attachments
  /root/.cache/pypoetry/virtualenvs/fastapi-mail-6GE7yTii-py3.8/lib/python3.8/site-packages/_pytest/python.py:195: ResourceWarning: unclosed file <_io.BufferedReader name='/root/fastapi-mail/tests/txt_files/plain.txt'>
    result = testfunction(**testargs)
  
  Object allocated at:
    File "/root/.cache/pypoetry/virtualenvs/fastapi-mail-6GE7yTii-py3.8/lib/python3.8/site-packages/_pytest/python.py", line 195
      result = testfunction(**testargs)
 ```
 
 With this edit, this remove some warnings
 ```
 
 tests/test_message.py::test_plain_message_with_attachments
  /root/.cache/pypoetry/virtualenvs/fastapi-mail-6GE7yTii-py3.8/lib/python3.8/site-packages/_pytest/python.py:195: ResourceWarning: unclosed file <_io.BufferedReader name='/root/fastapi-mail/tests/txt_files/plain.txt'>
    result = testfunction(**testargs)
  
  Object allocated at:
    File "/root/.cache/pypoetry/virtualenvs/fastapi-mail-6GE7yTii-py3.8/lib/python3.8/site-packages/_pytest/python.py", line 195
      result = testfunction(**testargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

I am not sure how to resolve the last one cos if I close the file in the `validate_file` method the test fails since some functions try to access the file when it's already closed