### PR TITLE
Use secret str

### DIFF
--- a/fastapi_mail/config.py
+++ b/fastapi_mail/config.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from aiosmtplib.api import DEFAULT_TIMEOUT
 from jinja2 import Environment, FileSystemLoader
-from pydantic import DirectoryPath, EmailStr, conint, SecretStr
+from pydantic import DirectoryPath, EmailStr, SecretStr, conint
 from pydantic_settings import BaseSettings as Settings
 
 

--- a/fastapi_mail/config.py
+++ b/fastapi_mail/config.py
@@ -2,13 +2,13 @@ from typing import Optional
 
 from aiosmtplib.api import DEFAULT_TIMEOUT
 from jinja2 import Environment, FileSystemLoader
-from pydantic import DirectoryPath, EmailStr, conint
+from pydantic import DirectoryPath, EmailStr, conint, SecretStr
 from pydantic_settings import BaseSettings as Settings
 
 
 class ConnectionConfig(Settings):
     MAIL_USERNAME: str
-    MAIL_PASSWORD: str
+    MAIL_PASSWORD: SecretStr
     MAIL_PORT: int
     MAIL_SERVER: str
     MAIL_STARTTLS: bool

--- a/fastapi_mail/connection.py
+++ b/fastapi_mail/connection.py
@@ -46,7 +46,7 @@ class Connection:
 
                 if self.settings.USE_CREDENTIALS:
                     await self.session.login(
-                        self.settings.MAIL_USERNAME, self.settings.MAIL_PASSWORD
+                        self.settings.MAIL_USERNAME, self.settings.MAIL_PASSWORD.get_secret_value()
                     )
 
         except Exception as error:

--- a/fastapi_mail/connection.py
+++ b/fastapi_mail/connection.py
@@ -46,7 +46,8 @@ class Connection:
 
                 if self.settings.USE_CREDENTIALS:
                     await self.session.login(
-                        self.settings.MAIL_USERNAME, self.settings.MAIL_PASSWORD.get_secret_value()
+                        self.settings.MAIL_USERNAME,
+                        self.settings.MAIL_PASSWORD.get_secret_value(),
                     )
 
         except Exception as error:


### PR DESCRIPTION
Use pydantic SecretStr instead of just str for ConnectionConfig to avoid exposing password logs, prints, etc.