### PR TITLE
Allow "sender" to be set per-message

### DIFF
--- a/fastapi_mail/fastmail.py
+++ b/fastapi_mail/fastmail.py
@@ -73,7 +73,7 @@ class FastMail(_MailMixin):
                 message, template
             )
         msg = MailMsg(message)
-        sender = await self.__sender()
+        sender = await self.__sender(message)
         return await msg._message(sender)
 
     async def __template_message_builder(
@@ -85,10 +85,10 @@ class FastMail(_MailMixin):
             template_data = self.check_data(message.template_body)
             return template.render(**template_data)
 
-    async def __sender(self) -> Union[EmailStr, str]:
-        sender = self.config.MAIL_FROM
-        if self.config.MAIL_FROM_NAME is not None:
-            return formataddr((self.config.MAIL_FROM_NAME, self.config.MAIL_FROM))
+    async def __sender(self, message: MessageSchema) -> Union[EmailStr, str]:
+        sender = message.from_email or self.config.MAIL_FROM
+        if (from_name := message.from_name or self.config.MAIL_FROM_NAME) is not None:
+            return formataddr((from_name, sender))
         return sender
 
     async def send_message(

--- a/fastapi_mail/schemas.py
+++ b/fastapi_mail/schemas.py
@@ -43,6 +43,8 @@ class MessageSchema(BaseModel):
     cc: List[EmailStr] = []
     bcc: List[EmailStr] = []
     reply_to: List[EmailStr] = []
+    from_email: Optional[EmailStr] = None
+    from_name: Optional[str] = None
     charset: str = "utf-8"
     subtype: MessageType
     multipart_subtype: MultipartSubtypeEnum = MultipartSubtypeEnum.mixed

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -128,6 +128,28 @@ def test_replyto():
     assert msg.reply_to == ["replyto@example.com"]
 
 
+def test_from_email():
+    msg = MessageSchema(
+        subject="subject",
+        recipients=[],
+        from_email="replyto@example.com",
+        subtype=MessageType.plain,
+    )
+
+    assert msg.from_email == "replyto@example.com"
+
+
+def test_from_name():
+    msg = MessageSchema(
+        subject="subject",
+        recipients=[],
+        from_name="No Reply",
+        subtype=MessageType.plain,
+    )
+
+    assert msg.from_name == "No Reply"
+
+
 def test_cc():
     msg = MessageSchema(
         subject="subject",


### PR DESCRIPTION
Resolves #229 

Add `from_email` and `from_name` to `MessageSchema`.

`FastMail.__sender` is set from `MessageSchema.from_email` and `MessageSchema.from_name`, defaulting to the options set by the `ConnectionConfig`.