### PR TITLE
config: add optional CERT_BUNDLE argument

### DIFF
--- a/fastapi_mail/config.py
+++ b/fastapi_mail/config.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from aiosmtplib.api import DEFAULT_TIMEOUT
 from jinja2 import Environment, FileSystemLoader
-from pydantic import DirectoryPath, EmailStr, conint
+from pydantic import FilePath, DirectoryPath, EmailStr, conint
 from pydantic_settings import BaseSettings as Settings
 
 
@@ -21,6 +21,7 @@ class ConnectionConfig(Settings):
     USE_CREDENTIALS: bool = True
     VALIDATE_CERTS: bool = True
     TIMEOUT: int = DEFAULT_TIMEOUT
+    CERT_BUNDLE: Optional[FilePath] = None
 
     def template_engine(self) -> Environment:
         """

--- a/fastapi_mail/connection.py
+++ b/fastapi_mail/connection.py
@@ -39,6 +39,7 @@ class Connection:
                 use_tls=self.settings.MAIL_SSL_TLS,
                 start_tls=self.settings.MAIL_STARTTLS,
                 validate_certs=self.settings.VALIDATE_CERTS,
+                cert_bundle=self.settings.CERT_BUNDLE,
             )
 
             if not self.settings.SUPPRESS_SEND:  # for test environ


### PR DESCRIPTION
This is useful when needing to pass a custom Certificate Bundle. For instance Proton Mail requires you to run a local software called Proton Mail Bridge to act as a proxy between your machine and Proton Mail servers. To correctly authenticate, you need export a TLS certificate from Proton Mail Bridge and pass it to the Config object in FastAPI Mail, so that aiosmtplib can work correctly.