### PR TITLE
fix(config): enable Jinja2 autoescape to prevent XSS vulnerabilities (#295)

### DIFF
--- a/fastapi_mail/config.py
+++ b/fastapi_mail/config.py
@@ -33,5 +33,5 @@ class ConnectionConfig(Settings):
             raise ValueError(
                 "Class initialization did not include a ``TEMPLATE_FOLDER`` ``PathLike`` object."
             )
-        template_env = Environment(loader=FileSystemLoader(folder))
+        template_env = Environment(loader=FileSystemLoader(folder), autoescape=True)
         return template_env


### PR DESCRIPTION
## Summary
- Added `autoescape=True` parameter to the Jinja2 Environment constructor
  in the `template_engine` method to enable automatic HTML/XML escaping

## Motivation
Fixes #295

The Jinja2 Environment was instantiated without the `autoescape` parameter,
which defaults to `False` in Jinja2. This creates a security vulnerability
where user-supplied data in email templates is not automatically escaped,
potentially allowing Cross-Site Scripting (XSS) attacks when malicious
content is included in template variables.

According to Jinja2 documentation and security best practices, autoescape
should be enabled for HTML/XML templates to prevent XSS vulnerabilities.

## Changes
- `fastapi_mail/config.py`:
  - Added `autoescape=True` to the `Environment()` constructor call in
    the `template_engine` method (line 36)

## Testing
- All 5 existing Jinja2 template tests pass without modification
- The change enables automatic escaping of HTML/XML special characters
  in template output while maintaining backward compatibility for
  existing template functionality

## Security Impact
This fix addresses a potential XSS vulnerability by ensuring that all
user-supplied data in email templates is automatically escaped according
to Jinja2 security recommendations.

## Author
Benjamin Aduo (@benaduo)
