### PR TITLE
fix(msg): RFC 2047 encode non-ASCII names in address headers

### DIFF
--- a/fastapi_mail/fastmail.py
+++ b/fastapi_mail/fastmail.py
@@ -112,7 +112,7 @@ class FastMail(_MailMixin):
     async def _sender(self, message: MessageSchema) -> Union[EmailStr, str]:
         sender = message.from_email or self.config.MAIL_FROM
         if (from_name := message.from_name or self.config.MAIL_FROM_NAME) is not None:
-            return formataddr((from_name, sender))
+            return formataddr((from_name, sender), charset="utf-8")
         return sender
 
     async def send_message(

--- a/fastapi_mail/msg.py
+++ b/fastapi_mail/msg.py
@@ -5,12 +5,16 @@ from email.message import EmailMessage, Message
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from email.utils import formatdate, make_msgid
+from email.utils import formataddr, formatdate, make_msgid
 from typing import Any, Union
 
 from .schemas import MessageType, MultipartSubtypeEnum
 
 PY3 = sys.version_info[0] == 3
+
+
+def _format_address(recipient: Any) -> str:
+    return formataddr((recipient.name, str(recipient.email)), charset="utf-8")
 
 
 class MailMsg:
@@ -144,21 +148,21 @@ class MailMsg:
 
         self.message["Date"] = formatdate(time.time(), localtime=True)
         self.message["Message-ID"] = self.msgId
-        self.message["To"] = ", ".join(str(recipient) for recipient in self.recipients)
+        self.message["To"] = ", ".join(_format_address(r) for r in self.recipients)
         self.message["From"] = sender
 
         if self.subject:
             self.message["Subject"] = self.subject
 
         if self.cc:
-            self.message["Cc"] = ", ".join(str(recipient) for recipient in self.cc)
+            self.message["Cc"] = ", ".join(_format_address(r) for r in self.cc)
 
         if self.bcc:
-            self.message["Bcc"] = ", ".join(str(recipient) for recipient in self.bcc)
+            self.message["Bcc"] = ", ".join(_format_address(r) for r in self.bcc)
 
         if self.reply_to:
             self.message["Reply-To"] = ", ".join(
-                str(recipient) for recipient in self.reply_to
+                _format_address(r) for r in self.reply_to
             )
 
         if self.attachments:

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -307,3 +307,47 @@ async def test_name_email_message_headers():
     assert msg_object["Cc"] == "CC User <cc@example.com>"
     assert msg_object["Bcc"] == "BCC User <bcc@example.com>"
     assert msg_object["Reply-To"] == "Reply User <reply@example.com>"
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_names_are_rfc2047_encoded():
+    """Recipient display names with non-ASCII characters must be RFC 2047
+    encoded so the resulting headers are 7-bit-clean. Without encoding, the
+    raw UTF-8 reaches the SMTP server, which on some providers (e.g.
+    Office 365) strips it and rejects the message with
+    `550 5.2.254 InvalidRecipientsException`."""
+    from email.header import decode_header
+    from email.utils import getaddresses
+
+    message = MessageSchema(
+        subject="test subject",
+        recipients=["Lukas Böhm <lboehm@example.com>"],
+        cc=["René Méndez <rmendez@example.com>"],
+        bcc=["Straße Müller <strasse@example.com>"],
+        reply_to=["Renée Doe <reply@example.com>"],
+        body="test",
+        subtype=MessageType.plain,
+    )
+
+    msg = MailMsg(message)
+    msg_object = await msg._message("sender@example.com")
+
+    def _decode(header_value):
+        name, addr = getaddresses([header_value])[0]
+        parts = decode_header(name)
+        return (
+            "".join(
+                chunk.decode(charset or "ascii") if isinstance(chunk, bytes) else chunk
+                for chunk, charset in parts
+            ),
+            addr,
+        )
+
+    for header in ("To", "Cc", "Bcc", "Reply-To"):
+        raw = msg_object[header].encode("ascii")  # must not raise
+        assert b"=?utf-8?" in raw, f"{header} is not RFC 2047 encoded: {raw!r}"
+
+    assert _decode(msg_object["To"]) == ("Lukas Böhm", "lboehm@example.com")
+    assert _decode(msg_object["Cc"]) == ("René Méndez", "rmendez@example.com")
+    assert _decode(msg_object["Bcc"]) == ("Straße Müller", "strasse@example.com")
+    assert _decode(msg_object["Reply-To"]) == ("Renée Doe", "reply@example.com")


### PR DESCRIPTION
## What

Encode non-ASCII display names in recipient headers (`To`, `Cc`, `Bcc`, `Reply-To`, `From`) via `email.utils.formataddr(..., charset="utf-8")` so they are RFC 2047 quoted-printable on the wire instead of raw UTF-8. ASCII names are unaffected — `formataddr` only escapes when needed, so existing tests pass unchanged.

## Reason

Fixes #316 (and addresses the root cause of #225).

`str(NameEmail("Lukas Böhm", "lboehm@example.com"))` returns `'Lukas Böhm <lboehm@example.com>'` — raw UTF-8. Older Python versions silently re-encoded such headers; Python 3.14 no longer does. Office 365's SMTP submission server then strips the non-ASCII bytes from the recipient and rejects the message with:

```
550 5.2.254 InvalidRecipientsException; Sender throttled due to continuous invalid recipients errors.
Recipient 'Lukas Bhm <lboehm@example.com>' is not resolved.
```

Repeated failures push the sender mailbox into a throttled state.

`formataddr(("Lukas Böhm", "lboehm@example.com"), charset="utf-8")` returns `'=?utf-8?q?Lukas_B=C3=B6hm?= <lboehm@example.com>'` — RFC 2047 compliant, ASCII-clean.

The same `charset="utf-8"` is also added to the existing `formataddr` call in `FastMail._sender` so `MAIL_FROM_NAME` gets the same protection.

## Test

New `test_non_ascii_names_are_rfc2047_encoded` in `tests/test_message.py` asserts that headers for umlaut/diacritic names are ASCII-encodable, contain `=?utf-8?` MIME markers, and round-trip back to the original Unicode via `decode_header` + `getaddresses`.

All 24 tests pass on Python 3.14.
