### PR TITLE
docs: fix broken contributor setup instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,32 +18,40 @@ Please refer to each project's style and contribution guidelines for submitting 
  1. **Fork** the repo on GitHub
  2. **Clone** the project to your own machine
  3. **Commit** changes to your own branch
- 4. **Push** your work 
+ 4. **Push** your work
  5. Submit a **Pull request** so that we can review your changes
-
 
 ### Before Start
 
+`fastapi-mail` uses [Poetry](https://python-poetry.org/) for dependency management.
+After forking and cloning the repo, install the project together with its
+development dependencies from the project root:
 
 ```sh
-$ bash install.sh   
-$ source .venv/bin/activate
-$ cat main.py
-or
-
+pip install poetry
+poetry install      # installs fastapi-mail plus the dev tools (pytest, black, isort, flake8, mypy)
+poetry shell        # activate the virtual environment Poetry created
 ```
-or run fastapi app with uvicron
-
-```sh
-uvicorn app:app --port 8000 --reload
-
-```
-
 
 NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 
-
 ### Testing
-------------
 
-For testing use **tox** 
+Run the test suite (pytest with coverage) via the Makefile:
+
+```sh
+make test
+```
+
+or run pytest directly:
+
+```sh
+pytest
+```
+
+Before opening a pull request, run the linters and type checks, and format the code:
+
+```sh
+make lint          # isort, black, flake8, mypy
+make format_code   # auto-format with isort + black
+```


### PR DESCRIPTION
Closes #303

## Problem
The **Before Start** section of `CONTRIBUTING.md` documents a setup flow that doesn't work against the current repo:

- `bash install.sh` — there is no `install.sh` in the repository.
- `cat main.py` and `uvicorn app:app` — there is no `main.py` or `app.py`.
- The ` ```sh ` code fences in the section are malformed.
- "For testing use **tox**" — `tox.ini` exists, but its `envlist` targets Python 3.6–3.9, while the project now requires Python ≥ 3.10; the actual maintained test path is pytest via the `Makefile`.

(As noted on the issue, this section "needs an update.")

## Fix
Rewrote **Before Start** and **Testing** to match the repo's real tooling, verified against `pyproject.toml`, `poetry.lock`, and the `Makefile`:

- Dev setup via Poetry: `pip install poetry` → `poetry install` → `poetry shell` (`poetry install` pulls in the dev tools: pytest, black, isort, flake8, mypy).
- Testing via `make test` (pytest + coverage) or `pytest` directly.
- Linting/formatting via `make lint` and `make format_code`.
- Fixed the malformed code fences and removed references to non-existent files.

Docs-only change — no code touched.
