### PR TITLE
feat: add FastMail.get_message() to return the prepared message without sending

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,6 +15,8 @@ class has following attributes and methods
     - message : where you define message sturcture for email
     - template_name : if you are using jinja2 consider template_name as well for passing HTML.
 
+- get_message : Builds and returns the prepared `email.message.Message` without sending it. It takes the same arguments as `send_message` (a single `MessageSchema` returns one message; a list returns a list). Useful when you need to sign the message (e.g. S/MIME or DKIM) or otherwise post-process it before delivering it through your own transport.
+
 
 ### ```ConnectionConfig``` class
 class has following attributes

--- a/fastapi_mail/fastmail.py
+++ b/fastapi_mail/fastmail.py
@@ -128,6 +128,36 @@ class FastMail(_MailMixin):
         )
         await self.__send_prepared_messages(prepared_messages)
 
+    async def get_message(
+        self,
+        message: Union[MessageSchema, list[MessageSchema]],
+        template_name: Optional[str] = None,
+        html_template: Optional[str] = None,
+        plain_template: Optional[str] = None,
+    ) -> Union[EmailMessage, Message, list[Union[EmailMessage, Message]]]:
+        """
+        Build and return the prepared email message(s) without sending them.
+
+        This runs the exact same preparation pipeline as ``send_message``
+        (template rendering, sender resolution and MIME construction), but
+        returns the resulting ``email.message.Message`` object(s) instead of
+        delivering them. It lets callers sign the message (e.g. S/MIME or DKIM)
+        or otherwise post-process it before sending it through their own
+        transport.
+
+        A single ``MessageSchema`` returns a single message; a list of
+        ``MessageSchema`` returns a list of messages in the same order.
+
+        See https://github.com/sabuhish/fastapi-mail/issues/234
+        """
+        messages = self.__normalize_messages(message)
+        prepared_messages = await self.__prepare_messages_for_sending(
+            messages, template_name, html_template, plain_template
+        )
+        if isinstance(message, list):
+            return prepared_messages
+        return prepared_messages[0]
+
     def __normalize_messages(
         self, message: Union[MessageSchema, list[MessageSchema]]
     ) -> list[MessageSchema]:

--- a/tests/test_get_message.py
+++ b/tests/test_get_message.py
@@ -1,0 +1,75 @@
+import pytest
+
+from fastapi_mail import ConnectionConfig, FastMail, MessageSchema, MessageType
+
+
+@pytest.mark.asyncio
+async def test_get_message_returns_prepared_message_without_sending(mail_config):
+    sender = f"{mail_config['MAIL_FROM_NAME']} <{mail_config['MAIL_FROM']}>"
+    msg = MessageSchema(
+        subject="testing",
+        recipients=["to@example.com"],
+        body="Test data",
+        subtype=MessageType.plain,
+    )
+    conf = ConnectionConfig(**mail_config)
+    fm = FastMail(conf)
+
+    with fm.record_messages() as outbox:
+        prepared = await fm.get_message(msg)
+
+        # get_message prepares the message but must NOT dispatch/send it
+        assert len(outbox) == 0
+
+    assert not isinstance(prepared, list)
+    assert prepared["Subject"] == "testing"
+    assert prepared["From"] == sender
+    assert prepared["To"] == "to <to@example.com>"
+    body = prepared.get_payload()[0].get_payload(decode=True).decode()
+    assert body == "Test data"
+
+
+@pytest.mark.asyncio
+async def test_get_message_bulk_returns_list(mail_config):
+    messages = [
+        MessageSchema(
+            subject="Test 1",
+            recipients=["user1@example.com"],
+            body="Body 1",
+            subtype=MessageType.plain,
+        ),
+        MessageSchema(
+            subject="Test 2",
+            recipients=["user2@example.com"],
+            body="Body 2",
+            subtype=MessageType.plain,
+        ),
+    ]
+    conf = ConnectionConfig(**mail_config)
+    fm = FastMail(conf)
+
+    prepared = await fm.get_message(messages)
+
+    assert isinstance(prepared, list)
+    assert len(prepared) == 2
+    assert prepared[0]["Subject"] == "Test 1"
+    assert prepared[1]["Subject"] == "Test 2"
+
+
+@pytest.mark.asyncio
+async def test_get_message_with_template(mail_config):
+    msg = MessageSchema(
+        subject="testing",
+        recipients=["to@example.com"],
+        template_body={"name": "Andrej"},
+        subtype=MessageType.html,
+    )
+    conf = ConnectionConfig(**mail_config)
+    fm = FastMail(conf)
+
+    prepared = await fm.get_message(msg, template_name="simple_jinja_template.html")
+
+    assert not isinstance(prepared, list)
+    assert prepared["Subject"] == "testing"
+    rendered = prepared.get_payload()[0].get_payload(decode=True).decode()
+    assert "Andrej" in rendered


### PR DESCRIPTION
Closes #234

## Motivation
#234 asks for a way to sign outgoing mail (e.g. S/MIME) — or, as the issue itself suggests, simply to "get the prepared message" so it can be signed and sent externally. Today the fully-built `email.message.Message` is only created inside the private send pipeline, so there is no supported way to obtain it without sending.

## Change
Adds a public async method `FastMail.get_message(...)` that runs the **same** preparation pipeline as `send_message` (template rendering, sender resolution, MIME construction) but **returns** the prepared `email.message.Message` instead of delivering it. It reuses the existing internal `__prepare_messages_for_sending`, so behaviour stays identical to `send_message`.

- Same arguments as `send_message` (`message`, `template_name`, `html_template`, `plain_template`).
- A single `MessageSchema` returns one message; a list returns a list.
- Opens no SMTP connection and dispatches nothing.

This unblocks the S/MIME / DKIM signing use case without fastapi-mail taking on a cryptography dependency — callers sign/post-process the returned message and send it via their own transport.

## Tests
`tests/test_get_message.py` (3 tests, all passing):
- single message → returns a prepared `Message` with correct headers/body, and asserts nothing is dispatched (`record_messages` outbox stays empty);
- list input → returns a list of prepared messages;
- templated message → template is rendered into the returned message.

Existing suite still green (`tests/test_connection.py`: 22 passed). `black`, `isort`, `flake8` clean; `mypy` clean on `fastmail.py`.

## Docs
Documented the new method in `docs/getting-started.md`.
